### PR TITLE
fix: removing link to `registerSW.js`

### DIFF
--- a/src/root.tsx
+++ b/src/root.tsx
@@ -13,7 +13,6 @@ export default function Root() {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="manifest" href="/manifest.webmanifest" />
-        <script src="registerSW.js"></script>
         <meta name="description" content="Opinionated, batteries included, PWA using Solid and Vite" />
         <link rel="icon" href="/favicon.ico" type="image/png" sizes="16x16" />
         <link rel="apple-touch-icon" href="/pwa-192x192.png" sizes="192x192" />


### PR DESCRIPTION
We don't need it since `useRegisterSW` already calls the `sw.js` file.

And yes, it's `sw.js` and not `registerSW.js`. That's why we get a
```console
registerSW.js:1 Uncaught SyntaxError: Unexpected token '<'
```
in the DevTools when loading the website.

Hope it helps !